### PR TITLE
Add images without xdebug

### DIFF
--- a/php-5.5-no-xdebug/Dockerfile
+++ b/php-5.5-no-xdebug/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:5.5
+
+RUN apt-get update \
+  && apt-get install -y libcurl4-openssl-dev sudo git libxslt-dev mercurial subversion zlib1g-dev graphviz zip libmcrypt-dev libicu-dev g++ \
+  && apt-get clean \
+  && docker-php-ext-install soap \
+  && docker-php-ext-install zip \
+  && docker-php-ext-install xsl \
+  && docker-php-ext-install mcrypt \
+  && docker-php-ext-install mbstring \
+  && docker-php-ext-install gettext \
+  && docker-php-ext-install curl \
+  && docker-php-ext-install mysql \
+  && docker-php-ext-install pdo_mysql \
+  && docker-php-ext-install json \
+  && docker-php-ext-install intl \
+  && docker-php-ext-install opcache
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php-5.6-no-xdebug/Dockerfile
+++ b/php-5.6-no-xdebug/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:5.6
+
+RUN apt-get update \
+  && apt-get install -y libcurl4-openssl-dev sudo git libxslt-dev mercurial subversion zlib1g-dev graphviz zip libmcrypt-dev libicu-dev g++ \
+  && apt-get clean \
+  && docker-php-ext-install soap \
+  && docker-php-ext-install zip \
+  && docker-php-ext-install xsl \
+  && docker-php-ext-install mcrypt \
+  && docker-php-ext-install mbstring \
+  && docker-php-ext-install gettext \
+  && docker-php-ext-install curl \
+  && docker-php-ext-install mysql \
+  && docker-php-ext-install pdo_mysql \
+  && docker-php-ext-install json \
+  && docker-php-ext-install intl \
+  && docker-php-ext-install opcache
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php-7.0-no-xdebug/Dockerfile
+++ b/php-7.0-no-xdebug/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7.0
+
+RUN apt-get update \
+  && apt-get install -y libcurl4-openssl-dev sudo git libxslt-dev mercurial subversion zlib1g-dev graphviz zip libmcrypt-dev libicu-dev g++ \
+  && apt-get clean \
+  && docker-php-ext-install soap \
+  && docker-php-ext-install zip \
+  && docker-php-ext-install xsl \
+  && docker-php-ext-install mcrypt \
+  && docker-php-ext-install mbstring \
+  && docker-php-ext-install gettext \
+  && docker-php-ext-install curl \
+  && docker-php-ext-install pdo_mysql \
+  && docker-php-ext-install json \
+  && docker-php-ext-install intl \
+  && docker-php-ext-install opcache
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Most CLI tools display warnings regarding serious performance impact when ran with xdebug enabled. For CI purposes there is no need to have xdebug enabled as you are not able to connect to the debugger anyway.
